### PR TITLE
Set verify property on session based on param

### DIFF
--- a/pyfortiapi.py
+++ b/pyfortiapi.py
@@ -50,6 +50,8 @@ class FortiGate:
 
         url = self.urlbase + 'logincheck'
 
+        session.verify=self.verify
+
         # Login
         session.post(url,
                      data='username={username}&secretkey={password}'.format(username=self.username,


### PR DESCRIPTION
Despite passing the verify param to every request, because we're using a session we also need to set the verify property on the session to actually respect it